### PR TITLE
feat(config): add sharedBrowserContext option to reuse browser context across HTTP client

### DIFF
--- a/config.d.ts
+++ b/config.d.ts
@@ -101,6 +101,11 @@ export type Config = {
   saveTrace?: boolean;
 
   /**
+   * Reuse the same browser context between all connected HTTP clients.
+   */
+  sharedBrowserContext?: boolean;
+
+  /**
    * Secrets are used to prevent LLM from getting sensitive data while
    * automating scenarios such as authentication.
    * Prefer the browser.contextOptions.storageState over secrets file as a more secure alternative.


### PR DESCRIPTION
## 📄 PR Description

### Summary

This PR adds the `sharedBrowserContext` configuration option.
The feature itself was already implemented in [[microsoft/playwright#37463](https://github.com/microsoft/playwright/pull/37463)](https://github.com/microsoft/playwright/pull/37463); this change only exposes the option so it can be enabled by users.

### Context

* Related issue: [[microsoft/playwright-mcp#1045](https://github.com/microsoft/playwright-mcp/issues/1045)](https://github.com/microsoft/playwright-mcp/issues/1045)
* Related PR: [[microsoft/playwright#37463](https://github.com/microsoft/playwright/pull/37463)](https://github.com/microsoft/playwright/pull/37463)

### Changes

* Added the `sharedBrowserContext?: boolean` option in the configuration.
* No functional changes other than allowing users to enable the existing feature.